### PR TITLE
Fixing Maven Build

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -66,7 +66,28 @@
       </plugins>
     </pluginManagement>
 
-    <plugins>
+    <plugins>    
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-enforcer-plugin</artifactId>
+        <version>1.4</version>
+        <executions>
+          <execution>
+            <id>enforce-java</id>
+            <goals>
+              <goal>enforce</goal>
+            </goals>
+            <configuration>
+              <rules>
+                <requireJavaVersion>
+                  <version>[1.6.0,1.8.0)</version>
+                </requireJavaVersion>
+              </rules>    
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
+    
       <plugin>
         <artifactId>maven-compiler-plugin</artifactId>
         <version>2.3.2</version>
@@ -142,7 +163,7 @@
   <properties>
     <tycho-version>0.22.0</tycho-version>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-    <xtext.version>2.7.3</xtext.version>
+    <xtext.version>2.8.2</xtext.version>
     <maven.compiler.source>1.6</maven.compiler.source>
     <maven.compiler.target>1.6</maven.compiler.target>
 
@@ -158,10 +179,12 @@
       <layout>p2</layout>
       <url>http://download.eclipse.org/releases/luna</url>
     </repository>
+    <!--
     <repository>
       <id>Xtext Update Site</id>
       <layout>p2</layout>
       <url>http://download.eclipse.org/modeling/tmf/xtext/updates/composite/releases/</url>
     </repository>
+    -->
   </repositories>
 </project>


### PR DESCRIPTION
Using a version of xtext that's in Maven Central, removing ephemeral repositories, and ensuring that we don't
build with Java8 as everything breaks.