### PR TITLE
update to use xtext 2.9.2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,4 +2,6 @@ language: java
 jdk:
   - openjdk7
   - openjdk6
+addons:
+   hostname: short-hostname
 script: mvn package

--- a/antlr4ide.ui/src/main/java/com/github/jknack/antlr4ide/ui/Antlr4UiModule.java
+++ b/antlr4ide.ui/src/main/java/com/github/jknack/antlr4ide/ui/Antlr4UiModule.java
@@ -18,6 +18,7 @@ import org.eclipse.xtext.ui.editor.syntaxcoloring.AbstractAntlrTokenToAttributeI
 import org.eclipse.xtext.ui.editor.syntaxcoloring.IHighlightingConfiguration;
 import org.eclipse.xtext.ui.editor.syntaxcoloring.ISemanticHighlightingCalculator;
 import org.eclipse.xtext.ui.resource.IResourceSetProvider;
+import org.eclipse.xtext.ui.resource.Storage2UriMapperJavaImpl;
 import org.eclipse.xtext.ui.resource.IStorage2UriMapperJdtExtensions;
 import org.eclipse.xtext.ui.resource.SimpleResourceSetProvider;
 import org.eclipse.xtext.ui.wizard.IProjectCreator;
@@ -145,7 +146,7 @@ public class Antlr4UiModule extends com.github.jknack.antlr4ide.ui.AbstractAntlr
   // https://bugs.eclipse.org/bugs/show_bug.cgi?id=424455
   public void configureIStorage2UriMapperJdtExtensions(final Binder binder) {
     binder.bind(IStorage2UriMapperJdtExtensions.class).toProvider(
-        Providers.of((IStorage2UriMapperJdtExtensions) null));
+        Providers.of((IStorage2UriMapperJdtExtensions) (new Storage2UriMapperJavaImpl())));
   }
 
   @Override

--- a/pom.xml
+++ b/pom.xml
@@ -163,7 +163,7 @@
   <properties>
     <tycho-version>0.22.0</tycho-version>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-    <xtext.version>2.8.2</xtext.version>
+    <xtext.version>2.9.2</xtext.version>
     <maven.compiler.source>1.6</maven.compiler.source>
     <maven.compiler.target>1.6</maven.compiler.target>
 


### PR DESCRIPTION
- update pom.xml to use xtext 2.9.2
- fix longstanding bug causing "failed to create injector" crash with xtext > 2.7.x
