### PR TITLE
Fix lexer rule for single line comment when comment is followed by EOF

### DIFF
--- a/antlr4ide.core/src/main/java/com/github/jknack/antlr4ide/parser/antlr/InternalAntlr4Lexer.g
+++ b/antlr4ide.core/src/main/java/com/github/jknack/antlr4ide/parser/antlr/InternalAntlr4Lexer.g
@@ -133,7 +133,7 @@ fragment RULE_LEXER_CHAR_SET : '[' ('\\' ~(('\r'|'\n'))|~(('\r'|'\n'|'\\'|']')))
 
 fragment RULE_ARG_ACTION : '[' (RULE_ARG_ACTION|('"')=>RULE_ACTION_STRING_LITERAL|('\'')=>RULE_ACTION_CHAR_LITERAL|~(('['|']')))* ']';
 
-RULE_SL_COMMENT : '//' ~(('\r'|'\n'))* '\r'? '\n';
+RULE_SL_COMMENT : '//' ~(('\r'|'\n'))* '\r'? '\n'?;
 
 RULE_ML_COMMENT : '/*' ( options {greedy=false;} : . )*'*/';
 


### PR DESCRIPTION
The RULE_SL_COMMENT expects an explicit '\n' but if comment is the last then there is not '\n'. Fixed by make the last '\n' optional.